### PR TITLE
Add copper to Cyprus

### DIFF
--- a/common/scripted_effects/ztr_state_traits.txt
+++ b/common/scripted_effects/ztr_state_traits.txt
@@ -81,6 +81,7 @@ copper_small_add_deposits = {
 				this = s:STATE_ATTICA
 				this = s:STATE_SKOPIA
 				this = s:STATE_WESTERN_THRACE
+				this = s:STATE_CYPRUS
 				this = s:STATE_MAZOVIA
 				this = s:STATE_BEKES
 				this = s:STATE_WALLACHIA


### PR DESCRIPTION
With the 1.10.3 (GDFIX) patch adding the iron and sulfur deposits of Cyprus, copper mining should be represented in this mod, too.

The metal literally derives its name from the island's in many Germanic and Romance languages, and copper mining was revived in early 20th (or late 19th) century - well in the game and mod's timeframe.